### PR TITLE
fix: add root path to link

### DIFF
--- a/src/components/ui/nav/nav.config.ts
+++ b/src/components/ui/nav/nav.config.ts
@@ -66,7 +66,7 @@ export const nav: NavItem[] = [
   },
   {
     title: "Programs",
-    href: "#programs",
+    href: "/#programs",
     // children: [
     //   {
     //     title: "Featured Programs or Services",


### PR DESCRIPTION
link was going nowhere on other pages because it's a homepage route