### PR TITLE
perf: improve FCP and Real Experience scores

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,35 @@
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpeg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ico
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ttf
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/components/ImageWrapper.astro
+++ b/src/components/ImageWrapper.astro
@@ -4,9 +4,12 @@ import { SanityImage, type WrapperProps } from "sanity-image";
 export type ImageProps<T extends React.ElementType = "img"> =
   WrapperProps<T> & {
     alt: string;
+    width?: number;
+    height?: number;
+    loading?: "eager" | "lazy";
   };
 
-const { id, className, alt } = Astro.props;
+const { id, className, alt, width, height, loading = "lazy" } = Astro.props;
 ---
 
 <SanityImage
@@ -14,4 +17,7 @@ const { id, className, alt } = Astro.props;
   id={id}
   className={className}
   alt={alt}
+  width={width}
+  height={height}
+  loading={loading}
 />

--- a/src/components/sections/Featured.astro
+++ b/src/components/sections/Featured.astro
@@ -66,6 +66,8 @@ const featuredSection = featuredSectionData?.at(0);
           id={featuredSection.image?.asset?._ref}
           alt={featuredSection.title}
           className="h-full w-full object-cover rounded-lg"
+          width={600}
+          height={400}
         />
       </div>
     </section>

--- a/src/components/sections/Welcome.astro
+++ b/src/components/sections/Welcome.astro
@@ -8,9 +8,11 @@ import logoImage from "@/assets/logo-fullcolor-white-tag.png";
   <div class="relative">
     <Image
       src={headerImage}
+      widths={[400, 800, 1200, 1600]}
       sizes="100vw"
       alt=""
       fetchpriority="high"
+      loading="eager"
       class="h-[400px] object-cover"
     />
     <div class="absolute bottom-0 w-full h-1/3">
@@ -24,6 +26,7 @@ import logoImage from "@/assets/logo-fullcolor-white-tag.png";
           src={logoImage}
           alt="QC Family Tree"
           fetchpriority="high"
+          loading="eager"
           class="sm:w-[400px] sm:h-[400px] w-[250px] h-[250px]"
         />
         <h1

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -62,6 +62,15 @@ const navWrapperClassName =
 
     <meta name="theme-color" content="#b3be35" />
 
+    <link rel="preload" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      href="https://fonts.gstatic.com/s/ubuntu/v20/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw9W-DMn8ACD7j17g.ttf"
+      as="font"
+      type="font/ttf"
+      crossorigin
+    />
+
     <Font cssVariable="--font-ubuntu" />
 
     <title>{title}</title>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Welcome from "@/components/sections/Welcome.astro";
 import Contact from "@/components/sections/Contact.astro";
 import Layout from "@/layouts/Layout.astro";

--- a/src/pages/rhizome/_signup.astro
+++ b/src/pages/rhizome/_signup.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "@/layouts/Layout.astro";
 import Header from "@/components/Header.astro";
 import headerImage from "@/assets/rhizome/header.jpg";

--- a/src/pages/rhizome/index.astro
+++ b/src/pages/rhizome/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from "@/layouts/Layout.astro";
 import { Image } from "astro:assets";
 import Header from "@/components/Header.astro";


### PR DESCRIPTION
- Prerender main pages for static CDN serving (instant TTFB)
- Add responsive image sizes to hero and logo images
- Add eager loading to above-the-fold images
- Add dimensions to Sanity images to prevent layout shifts
- Preload Ubuntu font for faster first paint
- Add Vercel edge headers for 1-year asset caching
- Add Sanity webhook for auto-deploys on content changes