### PR TITLE
feat(hfg): link workshops to events and add page padding

### DIFF
--- a/src/pages/here-for-good.astro
+++ b/src/pages/here-for-good.astro
@@ -21,9 +21,19 @@ const goals = [
 ];
 
 const currently = [
-  { text: "Hosting monthly free skill-building workshops and networking events", image: workshopsImage },
+  {
+    text: "Hosting monthly free skill-building workshops and networking events",
+    image: workshopsImage,
+    linkText: "workshops",
+    linkUrl: "/#events",
+  },
   { text: "Celebrating 40 Rhizome Coalition members", image: rhizomeImage, linkText: "Rhizome", linkUrl: "/rhizome" },
-  { text: "Providing vending opportunities for Rhizome members through monthly Arts Markets", image: marketImage, linkText: "Rhizome", linkUrl: "/rhizome" },
+  {
+    text: "Providing vending opportunities for Rhizome members through monthly Arts Markets",
+    image: marketImage,
+    linkText: "Rhizome",
+    linkUrl: "/rhizome",
+  },
   { text: "Planning an arts + wellness conference for Fall 2026", image: meetingImage },
 ];
 
@@ -47,51 +57,47 @@ const in2025 = [
         data-hero-section
         class="w-full relative min-h-[650px] flex items-center justify-center overflow-hidden"
       >
-      <Image
-        src={headerImage}
-        sizes="100vw"
-        alt="Here for Good Business Cooperative"
-        fetchpriority="high"
-        class="absolute inset-0 w-full h-full object-cover"
-      />
-      <div class="absolute inset-0 bg-black/50"></div>
-      <div class="relative z-10 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex flex-col items-center lg:items-start lg:flex-row lg:gap-12 gap-8">
-          <div class="flex flex-col items-center lg:items-start">
-            <Image
-              width={250}
-              height={250}
-              format="png"
-              src={logoImage}
-              alt="Here for Good"
-              loading="eager"
-              class="w-[250px] h-auto drop-shadow-lg"
-            />
-            <h1 class="flex flex-col font-semibold text-center lg:text-left gap-3 font-ubuntu -mt-8">
-              <span class="text-4xl sm:text-5xl lg:text-6xl text-secondary drop-shadow-lg">
-                Honoring Place.
-              </span>
-              <span class="text-2xl sm:text-3xl lg:text-4xl text-white drop-shadow-lg">
-                Growing Possibility.
-              </span>
-            </h1>
+        <Image
+          src={headerImage}
+          sizes="100vw"
+          alt="Here for Good Business Cooperative"
+          fetchpriority="high"
+          class="absolute inset-0 w-full h-full object-cover"
+        />
+        <div class="absolute inset-0 bg-black/50"></div>
+        <div class="relative z-10 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="flex flex-col items-center lg:items-start lg:flex-row lg:gap-12 gap-8">
+            <div class="flex flex-col items-center lg:items-start">
+              <Image
+                width={250}
+                height={250}
+                format="png"
+                src={logoImage}
+                alt="Here for Good"
+                loading="eager"
+                class="w-[250px] h-auto drop-shadow-lg"
+              />
+              <h1 class="flex flex-col font-semibold text-center lg:text-left gap-3 font-ubuntu -mt-8">
+                <span class="text-4xl sm:text-5xl lg:text-6xl text-secondary drop-shadow-lg"> Honoring Place. </span>
+                <span class="text-2xl sm:text-3xl lg:text-4xl text-white drop-shadow-lg"> Growing Possibility. </span>
+              </h1>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
     </div>
 
     <div class="pb-8 lg:pb-16 space-y-8 lg:space-y-16 px-4">
       <section class="mx-auto max-w-5xl text-center space-y-8">
         <p class="max-w-4xl mx-auto">
-          QC Family Tree has been tasked by the City of Charlotte to strengthen the Freedom-Wilkinson Corridor
-          by driving job creation, supporting business growth, and improving quality of life. To complete
-          this mission, we've established the <span class="font-semibold">Here for Good Business Cooperative</span>, an organization focused
+          QC Family Tree has been tasked by the City of Charlotte to strengthen the Freedom-Wilkinson Corridor by driving
+          job creation, supporting business growth, and improving quality of life. To complete this mission, we've
+          established the <span class="font-semibold">Here for Good Business Cooperative</span>, an organization focused
           on revitalization, identity, advocacy, and coordination of the corridor.
         </p>
         <p class="max-w-4xl mx-auto">
-          <span class="font-semibold">Our Vision</span> is a joyful, regenerative economy in the Freedom-Wilkinson
-          Corridor where business, creativity, and community evolve sustainably together.
+          <span class="font-semibold">Our Vision</span> is a joyful, regenerative economy in the Freedom-Wilkinson Corridor
+          where business, creativity, and community evolve sustainably together.
         </p>
       </section>
 
@@ -107,60 +113,72 @@ const in2025 = [
       <section class="mx-auto max-w-5xl space-y-6">
         <SectionHeading title="Goals" />
         <div class="grid gap-3 sm:grid-cols-2">
-          {goals.map((goal) => {
-            const Icon = goal.icon;
-            return (
-              <div class="flex items-center gap-3 rounded-xl border border-border bg-muted px-4 py-3">
-                <Icon className="w-5 h-5 text-foreground shrink-0" />
-                <span>{goal.text}</span>
-              </div>
-            );
-          })}
+          {
+            goals.map((goal) => {
+              const Icon = goal.icon;
+              return (
+                <div class="flex items-center gap-3 rounded-xl border border-border bg-muted px-4 py-3">
+                  <Icon className="w-5 h-5 text-foreground shrink-0" />
+                  <span>{goal.text}</span>
+                </div>
+              );
+            })
+          }
         </div>
       </section>
 
       <section class="mx-auto max-w-5xl space-y-6">
         <SectionHeading title="Currently We Are…" />
         <div class="grid gap-4 sm:grid-cols-2">
-          {currently.map((item) => (
-            <article class="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-              <div class="aspect-[3/2]">
-                <Image
-                  src={item.image}
-                  alt=""
-                  class="h-full w-full object-cover"
-                />
-              </div>
-              <p class="p-4 text-sm">
-                {item.linkText ? (
-                  <>
-                    {item.text.split(item.linkText)[0]}
-                    <a href={item.linkUrl} class="underline hover:text-primary">{item.linkText}</a>
-                    {item.text.split(item.linkText)[1]}
-                  </>
-                ) : item.text}
-              </p>
-            </article>
-          ))}
+          {
+            currently.map((item) => (
+              <article class="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+                <div class="aspect-[3/2]">
+                  {item.linkUrl ? (
+                    <a href={item.linkUrl} class="block h-full w-full">
+                      <Image src={item.image} alt="" class="h-full w-full object-cover hover:opacity-90 transition-opacity" />
+                    </a>
+                  ) : (
+                    <Image src={item.image} alt="" class="h-full w-full object-cover" />
+                  )}
+                </div>
+                <p class="p-4 text-sm">
+                  {item.linkText ? (
+                    <>
+                      {item.text.split(item.linkText)[0]}
+                      <a href={item.linkUrl} class="underline hover:text-primary">
+                        {item.linkText}
+                      </a>
+                      {item.text.split(item.linkText)[1]}
+                    </>
+                  ) : (
+                    item.text
+                  )}
+                </p>
+              </article>
+            ))
+          }
         </div>
       </section>
 
       <section class="mx-auto max-w-5xl space-y-6">
         <SectionHeading title="In 2025 We…" />
         <div class="relative border-l-2 border-accent/30 ml-4 space-y-6">
-          {in2025.map((item) => (
-            <div class="relative pl-8">
-              <span class="absolute -left-[9px] top-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent">
-                <CheckCircle2 className="h-2.5 w-2.5 text-white" />
-              </span>
-              <p>{item}</p>
-            </div>
-          ))}
+          {
+            in2025.map((item) => (
+              <div class="relative pl-8">
+                <span class="absolute -left-[9px] top-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent">
+                  <CheckCircle2 className="h-2.5 w-2.5 text-white" />
+                </span>
+                <p>{item}</p>
+              </div>
+            ))
+          }
         </div>
       </section>
     </div>
 
-    <div class="px-4">
+    <div class="px-4 pb-8 lg:pb-16">
       <FollowAlong instagramHandle="hereforgoodclt" facebookHandle="hereforgoodclt" list="hfgb" />
     </div>
   </div>


### PR DESCRIPTION

  This PR improves the navigation and layout of the Here For Good
  (HFG) page by linking the workshops call-to-action to the home
  page events section and normalizing page spacing.

  Changes
   - Enhanced Card Linking: Updated the currently section logic
     to wrap card images in a link when a linkUrl is present.
   - Workshops Link: Pointed the "workshops" card (both image and
     text) to /#events.
   - UI Consistency: Added standard bottom padding (pb-8
     lg:pb-16) to the FollowAlong section on the HFG page to
     match the layout of the About and Freedom Fridge pages.

  Verification
   - [x] Confirmed the workshops card redirects to the events
     anchor on the homepage.
   - [x] Verified that other cards in the "Currently We Are"
     section still function correctly.
   - [x] Confirmed the HFG page now has a consistent visual "end"
     with proper bottom padding.