### PR TITLE
[codex] Fix client-side event time rendering

### DIFF
--- a/src/components/Cards/Eventcard.astro
+++ b/src/components/Cards/Eventcard.astro
@@ -17,12 +17,11 @@ const { title, ctaLink, description, endDateTime, image, startDateTime } =
   <h2 class="font-ubuntu font-semibold sm:text-lg">{title}</h2>
   <div class="flex flex-col gap-2">
     <p
-      class="opacity-80"
+      class="inline-block h-6 w-56 rounded bg-muted animate-pulse"
       data-main-event-time
       data-start={startDateTime}
       data-end={endDateTime}
     >
-      Loading time...
     </p>
   </div>
 </a>
@@ -63,6 +62,7 @@ const { title, ctaLink, description, endDateTime, image, startDateTime } =
     const startDate = new Date(start);
     const endDate = new Date(end);
 
+    element.className = "opacity-80";
     element.innerHTML = `${timeFormat.format(startDate)} <span class="px-1 opacity-70">•</span> <span class="text-xs opacity-80">${getApproxDuration(startDate, endDate)}</span>`;
   });
 </script>

--- a/src/components/sections/events/list/index.astro
+++ b/src/components/sections/events/list/index.astro
@@ -86,14 +86,38 @@ const visibleDates = sortedDates.slice(0, 6);
         <p class="text-sm text-muted-foreground">Pick a day to preview the event.</p>
       </div>
       <p class="text-xs text-muted-foreground">
-        <span data-day-count>Loading...</span>
+        <span data-day-count>{visibleDates.length} day{visibleDates.length === 1 ? "" : "s"}</span>
       </p>
     </div>
 
     <div class="flex gap-2 overflow-x-auto pb-1 scrollbar-hide" data-day-rail>
-      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
-      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
-      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
+      {visibleDates.map((dateKey, index) => {
+        const dateObj = new Date(dateKey);
+        const firstEvent = groupedEvents[dateKey]?.[0];
+
+        return (
+          <button
+            type="button"
+            class={`min-w-24 shrink-0 rounded-xl border px-3 py-2 text-left transition-all ${index === 0 ? "border-accent bg-accent/10 text-accent" : "border-border bg-background/80 text-muted-foreground hover:border-accent/50 hover:text-foreground"}`}
+            data-day-button
+            data-day-key={dateKey}
+          >
+            <div class="text-[11px] font-semibold uppercase tracking-widest opacity-80">
+              {dateObj.toLocaleDateString("en-US", { weekday: "short" })}
+            </div>
+            <div class="text-sm font-bold">
+              {dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+            </div>
+            <div
+              class="text-xs opacity-80"
+              data-day-time
+              data-start={firstEvent?.startUtc}
+            >
+              <span class="inline-block h-4 w-14 rounded bg-muted animate-pulse"></span>
+            </div>
+          </button>
+        );
+      })}
     </div>
   </div>
 
@@ -124,8 +148,12 @@ const visibleDates = sortedDates.slice(0, 6);
                 <div class="p-4 md:p-5 space-y-3">
                   <div class="flex flex-wrap items-start justify-between gap-4">
                     <div class="space-y-1">
-                      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground" data-date-header data-date={dateObj.toISOString()}>
-                        Loading...
+                      <p
+                        class="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+                        data-date-header
+                        data-date={dateObj.toISOString()}
+                      >
+                        <span class="inline-block h-3 w-24 rounded bg-muted animate-pulse"></span>
                       </p>
                       <p class="text-sm text-muted-foreground">
                         {dateEvents.length === 1
@@ -167,12 +195,12 @@ const visibleDates = sortedDates.slice(0, 6);
                                 <div class="flex items-center gap-2">
                                   <Clock className="w-4 h-4 text-accent/70" />
                                   <span
-                                    class="font-medium"
+                                    class="font-medium inline-block min-w-24 rounded bg-muted/70 px-2 py-0.5 text-transparent animate-pulse"
                                     data-event-time
                                     data-start={event.startUtc}
                                     data-end={event.endUtc}
                                   >
-                                    Loading...
+                                    Loading
                                   </span>
                                 </div>
                                 <div class="flex items-start gap-2">
@@ -261,16 +289,12 @@ const visibleDates = sortedDates.slice(0, 6);
   </div>
 </div>
 
-<script type="application/json" id="eventbrite-events-data" set:html={JSON.stringify(events)}></script>
-
 <script>
-  const eventsDataEl = document.getElementById("eventbrite-events-data");
   const dayRail = document.querySelector("[data-day-rail]");
   const dayPanels = document.querySelectorAll("[data-day-panel]");
   const dayCount = document.querySelector("[data-day-count]");
 
-  if (eventsDataEl && dayRail && dayPanels.length && dayCount) {
-    const events = JSON.parse(eventsDataEl.textContent || "[]");
+  if (dayRail && dayPanels.length && dayCount) {
     // Astro owns the markup; the browser only hydrates the time-dependent text.
     const timeFormat = new Intl.DateTimeFormat("en-US", {
       hour: "numeric",
@@ -283,54 +307,13 @@ const visibleDates = sortedDates.slice(0, 6);
       day: "numeric",
       year: "numeric",
     });
-
-    const groupedEvents = events.reduce((groups, event) => {
-      const dateKey = new Date(event.startUtc).toDateString();
-      if (!groups[dateKey]) {
-        groups[dateKey] = [];
-      }
-      groups[dateKey].push(event);
-      return groups;
-    }, {});
-
-    const sortedDates = Object.keys(groupedEvents).sort(
-      (a, b) => new Date(a).getTime() - new Date(b).getTime(),
-    );
-    const visibleDates = sortedDates.slice(0, 6);
-
-    dayCount.textContent = `${visibleDates.length} day${visibleDates.length === 1 ? "" : "s"}`;
-    // Build the interactive rail in the browser so timezone-sensitive labels stay local.
-    dayRail.innerHTML = visibleDates
-      .map((dateKey, index) => {
-        const dateObj = new Date(dateKey);
-        const firstEvent = groupedEvents[dateKey]?.[0];
-
-        return `
-          <button
-            type="button"
-            class="min-w-24 shrink-0 rounded-xl border px-3 py-2 text-left transition-all ${index === 0 ? "border-accent bg-accent/10 text-accent" : "border-border bg-background/80 text-muted-foreground hover:border-accent/50 hover:text-foreground"}"
-            data-day-button
-            data-day-key="${dateKey}"
-          >
-            <div class="text-[11px] font-semibold uppercase tracking-widest opacity-80">
-              ${dateObj.toLocaleDateString("en-US", { weekday: "short" })}
-            </div>
-            <div class="text-sm font-bold">
-              ${dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-            </div>
-            <div class="text-xs opacity-80" data-day-time data-start="${firstEvent?.startUtc || ""}">
-              ${firstEvent?.startUtc ? timeFormat.format(new Date(firstEvent.startUtc)) : ""}
-            </div>
-          </button>
-        `;
-      })
-      .join("");
-
     const dayButtons = dayRail.querySelectorAll("[data-day-button]");
 
     document.querySelectorAll("[data-date-header]").forEach((element) => {
       const date = element.getAttribute("data-date");
       if (!date) return;
+      element.textContent = "";
+      element.classList.remove("text-transparent", "bg-muted/70", "animate-pulse");
       element.textContent = dayHeaderFormat.format(new Date(date));
     });
 
@@ -345,16 +328,19 @@ const visibleDates = sortedDates.slice(0, 6);
         minutes < 60
           ? `${minutes} min${minutes === 1 ? "" : "s"}`
           : `${Math.floor(minutes / 60)} hr${Math.floor(minutes / 60) === 1 ? "" : "s"}${minutes % 60 ? ` ${minutes % 60} min${minutes % 60 === 1 ? "" : "s"}` : ""}`;
-      element.innerHTML = `${timeFormat.format(startDate)} <span class="px-1 opacity-70">•</span> <span class="text-xs opacity-80">${duration}</span>`;
+      element.classList.remove("text-transparent", "bg-muted/70", "animate-pulse");
+      element.textContent = `${timeFormat.format(startDate)} • ${duration}`;
     });
 
     document.querySelectorAll("[data-day-time]").forEach((element) => {
       const start = element.getAttribute("data-start");
       if (!start) return;
+      element.textContent = "";
+      element.classList.remove("text-transparent", "bg-muted/70", "animate-pulse");
       element.textContent = timeFormat.format(new Date(start));
     });
 
-    const setActiveDay = (dayKey) => {
+    const setActiveDay = (dayKey: string) => {
       dayButtons.forEach((button) => {
         const isActive = button.getAttribute("data-day-key") === dayKey;
         button.classList.toggle("border-accent", isActive);

--- a/src/components/sections/events/list/index.astro
+++ b/src/components/sections/events/list/index.astro
@@ -1,5 +1,4 @@
 ---
-// src/components/EventListView.astro
 import {
   Calendar,
   Clock,
@@ -13,14 +12,13 @@ import {
   Check,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
 
 interface Event {
   id: string;
   title: string;
-  start: Date;
-  end: Date;
+  startUtc: string;
+  endUtc: string;
   location: string;
   description: string;
   category: "Workshop" | "Meeting" | "Community" | "Social";
@@ -33,6 +31,7 @@ interface Props {
 }
 
 const { events } = Astro.props;
+
 const getCategoryIcon = (category: string) => {
   switch (category) {
     case "Workshop":
@@ -48,19 +47,19 @@ const getCategoryIcon = (category: string) => {
   }
 };
 
-const formatDateHeader = (date: Date) => {
-  return date.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+const generateCalendarLink = (event: Event) => {
+  const startFormatted = event.startUtc.replace(/-|:|\.\d\d\d/g, "");
+  const endFormatted = event.endUtc.replace(/-|:|\.\d\d\d/g, "");
+  return `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${startFormatted}/${endFormatted}&details=${encodeURIComponent(event.description)}&location=${encodeURIComponent(event.location)}`;
 };
 
-// Group events by date
+const generateMapsLink = (location: string) => {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
+};
+
 const groupedEvents = events.reduce(
   (groups, event) => {
-    const dateKey = event.start.toDateString();
+    const dateKey = new Date(event.startUtc).toDateString();
     if (!groups[dateKey]) {
       groups[dateKey] = [];
     }
@@ -73,19 +72,8 @@ const groupedEvents = events.reduce(
 const sortedDates = Object.keys(groupedEvents).sort(
   (a, b) => new Date(a).getTime() - new Date(b).getTime(),
 );
+
 const visibleDates = sortedDates.slice(0, 6);
-
-// Helper to generate Google Calendar link
-const generateCalendarLink = (event: Event) => {
-  const startFormatted = event.start.toISOString().replace(/-|:|\.\d\d\d/g, "");
-  const endFormatted = event.end.toISOString().replace(/-|:|\.\d\d\d/g, "");
-
-  return `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${startFormatted}/${endFormatted}&details=${encodeURIComponent(event.description)}&location=${encodeURIComponent(event.location)}`;
-};
-
-const generateMapsLink = (location: string) => {
-  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
-};
 ---
 
 <div class="space-y-6 max-w-5xl mx-auto px-4 pb-4">
@@ -98,314 +86,319 @@ const generateMapsLink = (location: string) => {
         <p class="text-sm text-muted-foreground">Pick a day to preview the event.</p>
       </div>
       <p class="text-xs text-muted-foreground">
-        {visibleDates.length} day{visibleDates.length === 1 ? "" : "s"}
+        <span data-day-count>Loading...</span>
       </p>
     </div>
 
     <div class="flex gap-2 overflow-x-auto pb-1 scrollbar-hide" data-day-rail>
-      {
-        visibleDates.map((dateKey, index) => {
-          const dateObj = new Date(dateKey);
-          const dayEvents = groupedEvents[dateKey];
-
-          return (
-            <button
-              type="button"
-              class={`min-w-24 shrink-0 rounded-xl border px-3 py-2 text-left transition-all ${index === 0 ? "border-accent bg-accent/10 text-accent" : "border-border bg-background/80 text-muted-foreground hover:border-accent/50 hover:text-foreground"}`}
-              data-day-button
-              data-day-key={dateKey}
-            >
-              <div class="text-[11px] font-semibold uppercase tracking-widest opacity-80">
-                {dateObj.toLocaleDateString("en-US", { weekday: "short" })}
-              </div>
-              <div class="text-sm font-bold">
-                {dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-              </div>
-              <div class="text-xs opacity-80">
-                <span
-                  data-day-time
-                  class="inline-block h-4 w-16 animate-pulse rounded bg-muted"
-                ></span>
-              </div>
-            </button>
-          );
-        })
-      }
+      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
+      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
+      <div class="min-w-24 h-24 rounded-xl bg-muted animate-pulse"></div>
     </div>
   </div>
 
-    <div class="space-y-4">
-      {
-      visibleDates.map((dateKey, index) => {
-        const dateEvents = groupedEvents[dateKey];
-        const dateObj = new Date(dateKey);
+  <div class="space-y-4">
+    {events.length === 0 && (
+        <div class="text-center py-20 border-2 border-dashed border-border rounded-2xl bg-muted/50 max-w-2xl mx-auto">
+          <Calendar className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+          <p class="font-bold">No upcoming events found.</p>
+          <p class="text-sm text-muted-foreground">
+            Check back later for new workshops!
+          </p>
+        </div>
+    )}
 
-        return (
-          <article
-            class={`event-day-panel bg-card text-card-foreground overflow-hidden rounded-2xl border border-border shadow-sm transition-all ${index === 0 ? "" : "hidden"} max-w-2xl mx-auto`}
-            data-day-panel
-            data-day-key={dateKey}
-          >
-            <div class="p-4 md:p-5 space-y-3">
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div class="space-y-1">
-                  <p class="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    {formatDateHeader(dateObj)}
-                  </p>
-                  <p class="text-sm text-muted-foreground">
-                    {dateEvents.length === 1
-                      ? "1 event"
-                      : `${dateEvents.length} events`}
-                  </p>
-                </div>
-              </div>
+    {events.length > 0 && (
+      <>
+        {
+          visibleDates.map((dateKey, index) => {
+            const dateEvents = groupedEvents[dateKey];
+            const dateObj = new Date(dateKey);
 
-              <div class={`grid gap-4 ${dateEvents.length === 2 ? "md:grid-cols-2" : ""}`}>
-                {dateEvents.map((event) => {
-                  const CategoryIcon = getCategoryIcon(event.category);
+            return (
+              <article
+                class={`event-day-panel bg-card text-card-foreground overflow-hidden rounded-2xl border border-border shadow-sm transition-all ${index === 0 ? "" : "hidden"} max-w-2xl mx-auto`}
+                data-day-panel
+                data-day-key={dateKey}
+              >
+                <div class="p-4 md:p-5 space-y-3">
+                  <div class="flex flex-wrap items-start justify-between gap-4">
+                    <div class="space-y-1">
+                      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground" data-date-header data-date={dateObj.toISOString()}>
+                        Loading...
+                      </p>
+                      <p class="text-sm text-muted-foreground">
+                        {dateEvents.length === 1
+                          ? "1 event"
+                          : `${dateEvents.length} events`}
+                      </p>
+                    </div>
+                  </div>
 
-                  return (
-                    <div class="overflow-hidden rounded-xl border border-border bg-background/60">
-                      {event.imageUrl && (
-                        <div class="overflow-hidden border-b border-border bg-muted">
-                          <img
-                            src={event.imageUrl}
-                            alt={event.title}
-                            loading="lazy"
-                            class="block aspect-[4/3] max-h-[280px] min-h-[180px] w-full object-cover"
-                          />
-                        </div>
-                      )}
+                  <div class={`grid gap-4 ${dateEvents.length === 2 ? "md:grid-cols-2" : ""}`}>
+                    {
+                      dateEvents.map((event) => {
+                        const CategoryIcon = getCategoryIcon(event.category);
 
-                      <div class="p-4 space-y-3">
-                        <div class="flex justify-between items-start gap-4">
-                          <h5 class="font-bold leading-snug">
-                            {event.title}
-                          </h5>
-                          <div class="shrink-0 p-2 bg-muted rounded-lg text-muted-foreground">
-                            <CategoryIcon className="w-4 h-4" />
-                          </div>
-                        </div>
+                        return (
+                          <div class="overflow-hidden rounded-xl border border-border bg-background/60">
+                            {event.imageUrl && (
+                              <div class="overflow-hidden border-b border-border bg-muted">
+                                <img
+                                  src={event.imageUrl}
+                                  alt={event.title}
+                                  loading="lazy"
+                                  class="block aspect-[4/3] max-h-[280px] min-h-[180px] w-full object-cover"
+                                />
+                              </div>
+                            )}
 
-                        <div class="space-y-2 text-sm text-muted-foreground">
-                          <div class="flex items-center gap-2">
-                            <Clock className="w-4 h-4 text-accent/70" />
-                            <span
-                              class="font-medium inline-block min-w-24 rounded bg-muted/70 px-2 py-0.5 text-transparent animate-pulse"
-                              data-event-time
-                              data-start={event.start.toISOString()}
-                              data-end={event.end.toISOString()}
-                            >
-                              Loading
-                            </span>
-                          </div>
-                          <div class="flex items-start gap-2">
-                            <MapPin className="w-4 h-4 text-accent/70 mt-0.5" />
-                            <div class="flex items-start gap-2 min-w-0">
-                              {event.location !== "TBD" ? (
-                                <>
-                                  <a
-                                    href={generateMapsLink(event.location)}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    class="leading-tight underline-offset-4 hover:underline"
+                            <div class="p-4 space-y-3">
+                              <div class="flex justify-between items-start gap-4">
+                                <h5 class="font-bold leading-snug">
+                                  {event.title}
+                                </h5>
+                                <div class="shrink-0 p-2 bg-muted rounded-lg text-muted-foreground">
+                                  <CategoryIcon className="w-4 h-4" />
+                                </div>
+                              </div>
+
+                              <div class="space-y-2 text-sm text-muted-foreground">
+                                <div class="flex items-center gap-2">
+                                  <Clock className="w-4 h-4 text-accent/70" />
+                                  <span
+                                    class="font-medium"
+                                    data-event-time
+                                    data-start={event.startUtc}
+                                    data-end={event.endUtc}
                                   >
-                                    {event.location}
-                                  </a>
-                                  <button
-                                    type="button"
-                                    class="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                                    data-copy-location={event.location}
-                                    aria-label={`Copy address for ${event.title}`}
-                                    title="Copy address"
+                                    Loading...
+                                  </span>
+                                </div>
+                                <div class="flex items-start gap-2">
+                                  <MapPin className="w-4 h-4 text-accent/70 mt-0.5" />
+                                  <div class="flex items-start gap-2 min-w-0">
+                                    {event.location !== "TBD" ? (
+                                      <>
+                                        <a
+                                          href={generateMapsLink(event.location)}
+                                          target="_blank"
+                                          rel="noreferrer"
+                                          class="leading-tight underline-offset-4 hover:underline"
+                                        >
+                                          {event.location}
+                                        </a>
+                                        <button
+                                          type="button"
+                                          class="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                                          data-copy-location={event.location}
+                                          aria-label={`Copy address for ${event.title}`}
+                                          title="Copy address"
+                                        >
+                                          <Copy className="w-3.5 h-3.5 copy-icon" />
+                                          <Check className="hidden w-3.5 h-3.5 copied-icon text-secondary" />
+                                        </button>
+                                      </>
+                                    ) : (
+                                      <span class="leading-tight">{event.location}</span>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+
+                              <p class="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
+                                {event.description}
+                              </p>
+
+                              <div class="pt-1 flex flex-wrap items-center justify-between gap-3">
+                                <Badge variant="secondary" className="bg-secondary/10">
+                                  {event.category}
+                                </Badge>
+
+                                <div class="flex flex-wrap items-center gap-2">
+                                  {event.url && (
+                                    <Link
+                                      href={event.url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      variant="default"
+                                      size="sm"
+                                      className="!rounded-xl text-xs"
+                                    >
+                                      View event
+                                    </Link>
+                                  )}
+                                  <Link
+                                    href={generateCalendarLink(event)}
+                                    variant="outline"
+                                    size="sm"
+                                    className="!rounded-xl text-xs gap-1.5"
+                                    data-event-id={event.id}
+                                    data-event-title={event.title}
+                                    data-event-start={event.startUtc}
+                                    data-event-end={event.endUtc}
+                                    data-event-location={event.location}
+                                    data-event-description={event.description}
                                   >
-                                    <Copy className="w-3.5 h-3.5 copy-icon" />
-                                    <Check className="hidden w-3.5 h-3.5 copied-icon text-secondary" />
-                                  </button>
-                                </>
-                              ) : (
-                                <span class="leading-tight">{event.location}</span>
-                              )}
+                                    <CalendarPlus className="w-3.5 h-3.5" />
+                                    Add to Calendar
+                                  </Link>
+                                </div>
+                              </div>
                             </div>
                           </div>
-                        </div>
-
-                        <p class="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
-                          {event.description}
-                        </p>
-
-                        <div class="pt-1 flex flex-wrap items-center justify-between gap-3">
-                          <Badge variant="secondary" className="bg-secondary/10">
-                            {event.category}
-                          </Badge>
-
-                          <div class="flex flex-wrap items-center gap-2">
-                            {event.url && (
-                              <Link
-                                href={event.url}
-                                target="_blank"
-                                rel="noreferrer"
-                                variant="default"
-                                size="sm"
-                                className="!rounded-xl text-xs"
-                              >
-                                View event
-                              </Link>
-                            )}
-                            <Link
-                              href={generateCalendarLink(event)}
-                              variant="outline"
-                              size="sm"
-                              className="!rounded-xl text-xs gap-1.5"
-                              data-event-id={event.id}
-                              data-event-title={event.title}
-                              data-event-start={event.start.toISOString()}
-                              data-event-end={event.end.toISOString()}
-                              data-event-location={event.location}
-                              data-event-description={event.description}
-                            >
-                              <CalendarPlus className="w-3.5 h-3.5" />
-                              Add to Calendar
-                            </Link>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          </article>
-        );
-      })
-    }
-
-  {visibleDates.length === 0 && (
-    <div class="text-center py-20 border-2 border-dashed border-border rounded-2xl bg-muted/50">
-      <Calendar className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-      <p class="font-bold">No upcoming events found.</p>
-      <p class="text-sm text-muted-foreground">
-        Check back later for new workshops!
-      </p>
-    </div>
-  )}
+                        );
+                      })
+                    }
+                  </div>
+                </div>
+              </article>
+            );
+          })
+        }
+      </>
+    )}
+  </div>
 </div>
 
+<script type="application/json" id="eventbrite-events-data" set:html={JSON.stringify(events)}></script>
+
 <script>
-  const copyButtons = document.querySelectorAll("[data-copy-location]");
-  const timeFormat = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-  const dayButtons = document.querySelectorAll("[data-day-button]");
+  const eventsDataEl = document.getElementById("eventbrite-events-data");
+  const dayRail = document.querySelector("[data-day-rail]");
   const dayPanels = document.querySelectorAll("[data-day-panel]");
+  const dayCount = document.querySelector("[data-day-count]");
 
-  const setActiveDay = (dayKey: string) => {
+  if (eventsDataEl && dayRail && dayPanels.length && dayCount) {
+    const events = JSON.parse(eventsDataEl.textContent || "[]");
+    // Astro owns the markup; the browser only hydrates the time-dependent text.
+    const timeFormat = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    const dayHeaderFormat = new Intl.DateTimeFormat("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+    const groupedEvents = events.reduce((groups, event) => {
+      const dateKey = new Date(event.startUtc).toDateString();
+      if (!groups[dateKey]) {
+        groups[dateKey] = [];
+      }
+      groups[dateKey].push(event);
+      return groups;
+    }, {});
+
+    const sortedDates = Object.keys(groupedEvents).sort(
+      (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+    );
+    const visibleDates = sortedDates.slice(0, 6);
+
+    dayCount.textContent = `${visibleDates.length} day${visibleDates.length === 1 ? "" : "s"}`;
+    // Build the interactive rail in the browser so timezone-sensitive labels stay local.
+    dayRail.innerHTML = visibleDates
+      .map((dateKey, index) => {
+        const dateObj = new Date(dateKey);
+        const firstEvent = groupedEvents[dateKey]?.[0];
+
+        return `
+          <button
+            type="button"
+            class="min-w-24 shrink-0 rounded-xl border px-3 py-2 text-left transition-all ${index === 0 ? "border-accent bg-accent/10 text-accent" : "border-border bg-background/80 text-muted-foreground hover:border-accent/50 hover:text-foreground"}"
+            data-day-button
+            data-day-key="${dateKey}"
+          >
+            <div class="text-[11px] font-semibold uppercase tracking-widest opacity-80">
+              ${dateObj.toLocaleDateString("en-US", { weekday: "short" })}
+            </div>
+            <div class="text-sm font-bold">
+              ${dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+            </div>
+            <div class="text-xs opacity-80" data-day-time data-start="${firstEvent?.startUtc || ""}">
+              ${firstEvent?.startUtc ? timeFormat.format(new Date(firstEvent.startUtc)) : ""}
+            </div>
+          </button>
+        `;
+      })
+      .join("");
+
+    const dayButtons = dayRail.querySelectorAll("[data-day-button]");
+
+    document.querySelectorAll("[data-date-header]").forEach((element) => {
+      const date = element.getAttribute("data-date");
+      if (!date) return;
+      element.textContent = dayHeaderFormat.format(new Date(date));
+    });
+
+    document.querySelectorAll("[data-event-time]").forEach((element) => {
+      const start = element.getAttribute("data-start");
+      const end = element.getAttribute("data-end");
+      if (!start || !end) return;
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+      const minutes = Math.max(0, Math.round((endDate.getTime() - startDate.getTime()) / 60000));
+      const duration =
+        minutes < 60
+          ? `${minutes} min${minutes === 1 ? "" : "s"}`
+          : `${Math.floor(minutes / 60)} hr${Math.floor(minutes / 60) === 1 ? "" : "s"}${minutes % 60 ? ` ${minutes % 60} min${minutes % 60 === 1 ? "" : "s"}` : ""}`;
+      element.innerHTML = `${timeFormat.format(startDate)} <span class="px-1 opacity-70">•</span> <span class="text-xs opacity-80">${duration}</span>`;
+    });
+
+    document.querySelectorAll("[data-day-time]").forEach((element) => {
+      const start = element.getAttribute("data-start");
+      if (!start) return;
+      element.textContent = timeFormat.format(new Date(start));
+    });
+
+    const setActiveDay = (dayKey) => {
+      dayButtons.forEach((button) => {
+        const isActive = button.getAttribute("data-day-key") === dayKey;
+        button.classList.toggle("border-accent", isActive);
+        button.classList.toggle("bg-accent/10", isActive);
+        button.classList.toggle("text-accent", isActive);
+        button.classList.toggle("border-border", !isActive);
+        button.classList.toggle("bg-background/80", !isActive);
+        button.classList.toggle("text-muted-foreground", !isActive);
+      });
+
+      dayPanels.forEach((panel) => {
+        panel.classList.toggle("hidden", panel.getAttribute("data-day-key") !== dayKey);
+      });
+    };
+
+    const firstDay = dayButtons[0].getAttribute("data-day-key");
+    if (firstDay) setActiveDay(firstDay);
+
     dayButtons.forEach((button) => {
-      const isActive = button.getAttribute("data-day-key") === dayKey;
-      button.classList.toggle("border-accent", isActive);
-      button.classList.toggle("bg-accent/10", isActive);
-      button.classList.toggle("text-accent", isActive);
-      button.classList.toggle("border-border", !isActive);
-      button.classList.toggle("bg-background/80", !isActive);
-      button.classList.toggle("text-muted-foreground", !isActive);
+      button.addEventListener("click", () => {
+        const dayKey = button.getAttribute("data-day-key");
+        if (dayKey) setActiveDay(dayKey);
+      });
     });
 
-    dayPanels.forEach((panel) => {
-      panel.classList.toggle("hidden", panel.getAttribute("data-day-key") !== dayKey);
-    });
-  };
+    document.querySelectorAll("[data-copy-location]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const location = button.getAttribute("data-copy-location");
+        if (!location) return;
 
-  copyButtons.forEach((button) => {
-    button.addEventListener("click", async () => {
-      const location = button.getAttribute("data-copy-location");
-      if (!location) return;
-
-      try {
-        await navigator.clipboard.writeText(location);
-        const copyIcon = button.querySelector(".copy-icon");
-        const copiedIcon = button.querySelector(".copied-icon");
-        copyIcon?.classList.add("hidden");
-        copiedIcon?.classList.remove("hidden");
-        const existingTimeout = button.getAttribute("data-copy-timeout");
-        if (existingTimeout) {
-          clearTimeout(Number(existingTimeout));
+        try {
+          await navigator.clipboard.writeText(location);
+          const copyIcon = button.querySelector(".copy-icon");
+          const copiedIcon = button.querySelector(".copied-icon");
+          copyIcon?.classList.add("hidden");
+          copiedIcon?.classList.remove("hidden");
+          window.setTimeout(() => {
+            copyIcon?.classList.remove("hidden");
+            copiedIcon?.classList.add("hidden");
+          }, 3000);
+        } catch (error) {
+          console.error("Failed to copy event location", error);
         }
-        const timeoutId = window.setTimeout(() => {
-          copyIcon?.classList.remove("hidden");
-          copiedIcon?.classList.add("hidden");
-          button.removeAttribute("data-copy-timeout");
-        }, 5000);
-        button.setAttribute("data-copy-timeout", String(timeoutId));
-      } catch (error) {
-        console.error("Failed to copy event location", error);
-      }
+      });
     });
-  });
-
-  const getApproxDuration = (start: Date, end: Date) => {
-    const minutes = Math.max(0, Math.round((end.getTime() - start.getTime()) / 60000));
-
-    if (minutes < 60) {
-      return `${minutes} min${minutes === 1 ? "" : "s"}`;
-    }
-
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-
-    if (!remainingMinutes) {
-      return `${hours} hr${hours === 1 ? "" : "s"}`;
-    }
-
-    return `${hours} hr${hours === 1 ? "" : "s"} ${remainingMinutes} min${remainingMinutes === 1 ? "" : "s"}`;
-  };
-
-  document.querySelectorAll("[data-event-time]").forEach((element) => {
-    const start = element.getAttribute("data-start");
-    const end = element.getAttribute("data-end");
-
-    if (!start || !end) return;
-
-    const startDate = new Date(start);
-    const endDate = new Date(end);
-
-    element.className = "font-medium";
-    element.innerHTML = `${timeFormat.format(startDate)} <span class="px-1 opacity-70">•</span> <span class="text-xs opacity-80">${getApproxDuration(startDate, endDate)}</span>`;
-  });
-
-  document.querySelectorAll("[data-day-time]").forEach((element) => {
-    const dayButton = element.closest("[data-day-button]");
-    const dayKey = dayButton?.getAttribute("data-day-key");
-
-    if (!dayKey) return;
-
-    const dayPanel = document.querySelector(`[data-day-panel][data-day-key="${dayKey}"]`);
-    const firstEventTime = dayPanel?.querySelector("[data-event-time]");
-    const start = firstEventTime?.getAttribute("data-start");
-
-    if (!start) {
-      element.className = "inline-block h-4 w-12 rounded bg-muted";
-      return;
-    }
-
-    element.className = "";
-    element.textContent = timeFormat.format(new Date(start));
-  });
-
-  if (dayButtons.length > 0) {
-    const initialDayKey = dayButtons[0].getAttribute("data-day-key");
-    if (initialDayKey) {
-      setActiveDay(initialDayKey);
-    }
   }
-
-  dayButtons.forEach((button) => {
-    button.addEventListener("click", () => {
-      const dayKey = button.getAttribute("data-day-key");
-      if (dayKey) {
-        setActiveDay(dayKey);
-      }
-    });
-  });
 </script>

--- a/src/components/sections/events/list/index.astro
+++ b/src/components/sections/events/list/index.astro
@@ -33,7 +33,6 @@ interface Props {
 }
 
 const { events } = Astro.props;
-
 const getCategoryIcon = (category: string) => {
   switch (category) {
     case "Workshop":
@@ -47,14 +46,6 @@ const getCategoryIcon = (category: string) => {
     default:
       return Calendar;
   }
-};
-
-const formatTime = (date: Date) => {
-  return date.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
 };
 
 const formatDateHeader = (date: Date) => {
@@ -131,7 +122,10 @@ const generateMapsLink = (location: string) => {
                 {dateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
               </div>
               <div class="text-xs opacity-80">
-                {dayEvents[0]?.start ? formatTime(dayEvents[0].start) : "TBD"}
+                <span
+                  data-day-time
+                  class="inline-block h-4 w-16 animate-pulse rounded bg-muted"
+                ></span>
               </div>
             </button>
           );
@@ -197,12 +191,12 @@ const generateMapsLink = (location: string) => {
                           <div class="flex items-center gap-2">
                             <Clock className="w-4 h-4 text-accent/70" />
                             <span
-                              class="font-medium"
+                              class="font-medium inline-block min-w-24 rounded bg-muted/70 px-2 py-0.5 text-transparent animate-pulse"
                               data-event-time
                               data-start={event.start.toISOString()}
                               data-end={event.end.toISOString()}
                             >
-                              {formatTime(event.start)}
+                              Loading
                             </span>
                           </div>
                           <div class="flex items-start gap-2">
@@ -376,7 +370,27 @@ const generateMapsLink = (location: string) => {
     const startDate = new Date(start);
     const endDate = new Date(end);
 
+    element.className = "font-medium";
     element.innerHTML = `${timeFormat.format(startDate)} <span class="px-1 opacity-70">•</span> <span class="text-xs opacity-80">${getApproxDuration(startDate, endDate)}</span>`;
+  });
+
+  document.querySelectorAll("[data-day-time]").forEach((element) => {
+    const dayButton = element.closest("[data-day-button]");
+    const dayKey = dayButton?.getAttribute("data-day-key");
+
+    if (!dayKey) return;
+
+    const dayPanel = document.querySelector(`[data-day-panel][data-day-key="${dayKey}"]`);
+    const firstEventTime = dayPanel?.querySelector("[data-event-time]");
+    const start = firstEventTime?.getAttribute("data-start");
+
+    if (!start) {
+      element.className = "inline-block h-4 w-12 rounded bg-muted";
+      return;
+    }
+
+    element.className = "";
+    element.textContent = timeFormat.format(new Date(start));
   });
 
   if (dayButtons.length > 0) {

--- a/src/components/ui/nav/mobile.tsx
+++ b/src/components/ui/nav/mobile.tsx
@@ -108,7 +108,7 @@ export default function HamburgerMenu({
           <Button
             variant="ghost"
             size="icon"
-            className={`md:hidden ${open ? "hidden" : ""}`}
+            className={cn("md:hidden", open && "hidden")}
           >
             <Menu className="h-5 w-5" />
             <span className="sr-only">Toggle menu</span>
@@ -116,7 +116,10 @@ export default function HamburgerMenu({
         </SheetTrigger>
         <a
           href="/"
-          className={`md:hidden flex h-10 items-center ml-auto transition-opacity duration-200 ${open ? "hidden" : ""}`}
+          className={cn(
+            "md:hidden flex h-10 items-center ml-auto transition-opacity duration-200",
+            open && "hidden",
+          )}
           aria-label="QC Family Tree home"
           data-mobile-nav-logo
         >

--- a/src/lib/eventbrite.ts
+++ b/src/lib/eventbrite.ts
@@ -14,8 +14,8 @@ const eventbriteCache = new Map<
 export interface EventbriteEvent {
   id: string;
   title: string;
-  start: Date;
-  end: Date;
+  startUtc: string;
+  endUtc: string;
   location: string;
   description: string;
   category: "Workshop" | "Meeting" | "Community" | "Social";
@@ -214,14 +214,11 @@ async function getDefaultOrganizationId(): Promise<string | null> {
 }
 
 function mapEventbriteEvent(event: EventbriteApiEvent): EventbriteEvent {
-  const start = new Date(event.start.local);
-  const end = new Date(event.end.local);
-
   return {
     id: event.id,
     title: event.name.text,
-    start,
-    end,
+    startUtc: event.start.utc,
+    endUtc: event.end.utc,
     location: event.venue?.address.localized_address_display || "TBD",
     description: event.description.text || "",
     category: extractCategory(event.name.text, event.description.text),


### PR DESCRIPTION
## Summary

- Make event times render in the browser so visitors see local time.
- Replace loading text with skeleton placeholders.

## Why

- Avoid server-side timezone mismatches in the prerendered events UI.
- Keep the initial render visually intentional while the browser formats times.

## Validation

- Cherry-picked the time-rendering fix onto a fresh branch from `main`.
- Reviewed the affected event list and card components.
